### PR TITLE
Fix Namespace not specified. Specify a namespace in the module's

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    namespace = "com.twwm.share_files_and_screenshot_widgets"
     compileSdkVersion 29
 
     defaultConfig {


### PR DESCRIPTION
Was having an issue after upgrading my working environments:

**I fixed the issue by adding namespace to android block in build.gradle** 
--------------------------------------------

D:\GRAND_MASTER\GRAND_PRO\PROJECTS\DIIGITAL BUSINESS CARDS\APPS\smartbooks_vip_app\android>gradlew clean

FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':share_files_and_screenshot_widgets_plus'.
> _Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl._
   > Namespace not specified. Specify a namespace in the module's build file. See https://d.android.com/r/tools/upgrade-assistant/set-namespace for information about setting the namespace.

     If you've specified the package attribute in the source AndroidManifest.xml, you can use the AGP Upgrade Assistant to migrate to the namespace value in the build file. Refer to https://d.android.com/r/tools/upgrade-assistant/agp-upgrade-assistant for general information about using the AGP Upgrade Assistant.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.3/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD FAILED in 18s
4 actionable tasks: 4 up-to-date

D:\GRAND_MASTER\GRAND_PRO\PROJECTS\DIIGITAL BUSINESS CARDS\APPS\smartbooks_vip_app\android>gradlew clean

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.3/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 1m 50s
17 actionable tasks: 1 executed, 16 up-to-date